### PR TITLE
Test network-engine against devel & stable, py2 & py3

### DIFF
--- a/roles/ansible-role-tests/tasks/main.yaml
+++ b/roles/ansible-role-tests/tasks/main.yaml
@@ -1,18 +1,21 @@
 # As root file system is read only install packages with `--user`
-# Ansible is already installed, so install we are using the latest version
-- name: Install latest stable version of Ansible
+# Ansible is already installed, so install we are `--force` installing the correct version
+
+- name: Install the required version of Ansible
   pip:
-    name: ansible
+    name: "{{ ansible_pip_package }}"
     extra_args: --user
     state: forcereinstall
+    executable: "{{ pip }}"
 
 - name: Install textfsm
   pip:
     name: textfsm
     extra_args: --user
+    executable: "{{ pip }}"
 
-# FIXME Future: Need to run this under different Python versions
+# FIXME May need to add a sanity check that ansible --version returns the correct version of Python
 - name: Run integration tests
-  command: "ansible-playbook --inventory ./inventory test.yml -vv"
+  command: "/home/zuul-worker/.local/bin/ansible-playbook --inventory ./inventory test.yml -vv"
   args:
     chdir: "{{ ansible_network_engine_path }}/tests/"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,3 +1,7 @@
+##
+# `ansible-test sanity`
+# Single job tests multiple Python versions
+#
 - job:
     name: ansible-test-sanity
     description: ansible-test sanity
@@ -11,10 +15,78 @@
         # We need a container with various Python versions available
         name: container
         label: f27-oci
-- job:
+
+##
+# ansible-role-tests
+#   ansible:stable py2 & py3
+#   ansible:devel  py2
+#
+
+- job: # REMOVE THIS once live
     name: ansible-role-tests
-    description: ansible-role tests
+    description: ansible-role tests against Stable Ansible with Python 2
     run: playbooks/ansible-role-tests/run.yaml
     required-projects:
       - name: ansible-network/network-engine-zuul
         override-checkout: devel
+    vars:
+      pip: pip2
+    nodeset:
+      nodes:
+        # We need a container with various Python versions available
+        name: container
+        label: f27-oci
+- job:
+    name: ansible-role-tests-base
+    description: |
+      Parent job for ``ansible role`` tests for testing against different
+      Ansible and Python versions
+
+      Responds to these variables:
+
+      .. zuul:jobvar:: pip
+
+         Name of pip binary to use to install dependencies to allow testing
+         against different Python versions.
+
+         Example ``pip2`` or ``pip3``
+
+      .. zuul:jobvar:: ansible_pip_package
+
+         Provides the ability to pip install different versions of Ansible
+
+         Example ``ansible`` or ``"git+https://github.com/ansible/ansible.git@devel"``
+
+    run: playbooks/ansible-role-tests/run.yaml
+    required-projects:
+      - name: ansible-network/network-engine-zuul
+        override-checkout: devel
+    nodeset:
+      nodes:
+        # We need a container with various Python versions available
+        name: container
+        label: f27-oci
+
+- job:
+    name: ansible-role-tests-stable-py2
+    description: ansible-role tests against stable Ansible with Python 2
+    parent: ansible-role-tests-base
+    vars:
+      pip: pip2
+      ansible_pip_package: ansible
+
+- job:
+    name: ansible-role-tests-stable-py3
+    description: ansible-role tests against stable Ansible with Python 3
+    parent: ansible-role-tests-base
+    vars:
+      pip: pip3
+      ansible_pip_package: ansible
+
+- job:
+    name: ansible-role-tests-devel-py2
+    description: ansible-role tests against devel Ansible with Python 2
+    parent: ansible-role-tests-base
+    vars:
+      pip: pip2
+      ansible_pip_package: "git+https://github.com/ansible/ansible.git@devel"

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,7 +2,9 @@
     check:
       jobs:
         - tox-linters
-        - ansible-role-tests
+        - ansible-role-tests-stable-py2
+        - ansible-role-tests-stable-py3
+        - ansible-role-tests-devel-py2
     gate:
       jobs:
         - tox-linters


### PR DESCRIPTION
This role adds pre-commit integration tests for `network-engine` for both Python 2 and Python 3 using the latest stable released version of Ansible. 

In addition we use Ansible devel with Python 2 to ensure there aren't any upstream changes that might cause us issues. 

The `network-engine` role only supports Ansible 2.5.0 and newer, so no point testing on older Ansible releases. 

Although the roles are only "supported" on released versions of Ansible
we should ensure there are no regressions in the devel branch of Ansible.

stable: py2 & py3
deve: py2