### PR TITLE
[WIP] Don't hardcode repo to test

### DIFF
--- a/roles/ansible-role-tests/tasks/main.yaml
+++ b/roles/ansible-role-tests/tasks/main.yaml
@@ -18,4 +18,4 @@
 - name: Run integration tests
   command: "/home/zuul-worker/.local/bin/ansible-playbook --inventory ./inventory test.yml -vv"
   args:
-    chdir: "{{ ansible_network_engine_path }}/tests/"
+    chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/tests/"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -26,9 +26,6 @@
     name: ansible-role-tests
     description: ansible-role tests against Stable Ansible with Python 2
     run: playbooks/ansible-role-tests/run.yaml
-    required-projects:
-      - name: ansible-network/network-engine-zuul
-        override-checkout: devel
     vars:
       pip: pip2
     nodeset:
@@ -58,9 +55,6 @@
          Example ``ansible`` or ``"git+https://github.com/ansible/ansible.git@devel"``
 
     run: playbooks/ansible-role-tests/run.yaml
-    required-projects:
-      - name: ansible-network/network-engine-zuul
-        override-checkout: devel
     nodeset:
       nodes:
         # We need a container with various Python versions available

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,9 +2,6 @@
     check:
       jobs:
         - tox-linters
-        - ansible-role-tests-stable-py2
-        - ansible-role-tests-stable-py3
-        - ansible-role-tests-devel-py2
     gate:
       jobs:
         - tox-linters


### PR DESCRIPTION
Previously we were instructing Zuul to clone the `network-engine:devel` branch, rather than the PR we were testing 

With this fix we test the code from the PR which Zuul automatically checks out into  `/home/zuul-worker/src/github.com/ansible-network/network-engine-zuul/tests`

This has show that we were running the wrong tests on PRs on `ansible-network/ansible-zuul-jobs`, they should be run in `ansible-network/network-engine(-zuul)` not in here, see https://github.com/ansible-network/network-engine-zuul/pull/18/files