### PR TITLE
Remove ansible-role-tests as replaced by Python specific tests

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -22,18 +22,6 @@
 #   ansible:devel  py2
 #
 
-- job: # REMOVE THIS once live
-    name: ansible-role-tests
-    description: ansible-role tests against Stable Ansible with Python 2
-    run: playbooks/ansible-role-tests/run.yaml
-    vars:
-      pip: pip2
-      ansible_pip_package: ansible
-    nodeset:
-      nodes:
-        # We need a container with various Python versions available
-        name: container
-        label: f27-oci
 - job:
     name: ansible-role-tests-base
     description: |


### PR DESCRIPTION
The original ansible-role-tests has been replaced by specific tests for
different Python and Ansible versions