### PR TITLE
Use ansible-test from stable-2.5

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -9,7 +9,7 @@
     required-projects:
       # Needed for access to ansible-test
       - name: ansible/ansible
-        override-checkout: devel
+        override-checkout: stable-2.5
     nodeset:
       nodes:
         # We need a container with various Python versions available


### PR DESCRIPTION
Use the stable version of ansible-test for testing this role.

As in network-engine:2.5.1 we've set _text_parser.py with `removed_in:
"2.6"` this is (rightly) throwing an error as the module should have
been removed.

The network-engine roll actually follows the STABLE release of ansible