### PR TITLE
Run tests against Ansible stable-2.6

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -66,6 +66,24 @@
       pip: pip3
       ansible_pip_package: ansible
 
+# START: TMP while stable != stable-2.6
+- job:
+    name: ansible-role-tests-2.6-py2
+    description: ansible-role tests against stable-2.6 Ansible with Python 2
+    parent: ansible-role-tests-base
+    vars:
+      pip: pip2
+      ansible_pip_package: "git+https://github.com/ansible/ansible.git@stable-2.6"
+
+- job:
+    name: ansible-role-tests-2.6-py3
+    description: ansible-role tests against stable-2.6 Ansible with Python 3
+    parent: ansible-role-tests-base
+    vars:
+      pip: pip3
+      ansible_pip_package: "git+https://github.com/ansible/ansible.git@stable-2.6"
+
+# END: TMP while stable != stable-2.6
 - job:
     name: ansible-role-tests-devel-py2
     description: ansible-role tests against devel Ansible with Python 2


### PR DESCRIPTION
This ensure we are testing the roles against Ansible 2.6, as now Ansible
has a stable-2.6 branch without this we'd only be testing on devel and
latest (2.5)