### PR TITLE
Test against named versions, not "stable"

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -96,25 +96,3 @@
     vars:
       pip: pip3
       ansible_pip_package: "git+https://github.com/ansible/ansible.git@stable-2.5"
-
-
-
-
-
-###
-# Old jobs, delete once network-engine has been updated
-- job:
-    name: ansible-role-tests-stable-py2
-    description: ansible-role tests against stable Ansible with Python 2
-    parent: ansible-role-tests-base
-    vars:
-      pip: pip2
-      ansible_pip_package: ansible
-
-- job:
-    name: ansible-role-tests-stable-py3
-    description: ansible-role tests against stable Ansible with Python 3
-    parent: ansible-role-tests-base
-    vars:
-      pip: pip3
-      ansible_pip_package: ansible


### PR DESCRIPTION
The "stable" release is a moving target, we now use named releases.

We can delete these old entries as https://github.com/ansible-network/network-engine/pull/106/files has been merged
Follows on from https://github.com/ansible-network/ansible-zuul-jobs/pull/22