### PR TITLE
Add documentation for zuul jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
+# Backup files
+*~
+\#*\#
+
+# Unit test / coverage reports
+.coverage
 .tox
+
+# Docs build: Sphinx
+doc/build
+
+# Docs build: pbr generates these
+AUTHORS
+ChangeLog

--- a/README
+++ b/README
@@ -1,6 +1,0 @@
-# sf-jobs content
-
-This directory contains Zuul jobs.
-It includes of in-progress openstack-infra/zuul-jobs.
-It can also be used to store local jobs to be used by any projects in the local tenant.
-

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,7 @@
+Ansible Zuul jobs
+=================
+
+This repo contains a set of ansible playbooks which are used by the
+Ansible project CI system Zuul. It also contains job and
+project-template definitions for the Ansible project. You should
+edit these files to make configuration changes to Ansible CI.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+# -- General configuration ----------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    #'sphinx.ext.intersphinx',
+    'zuul_sphinx',
+]
+
+# autodoc generation is a bit aggressive and a nuisance when doing heavy
+# text edit cycles.
+# execute "export SPHINX_DEBUG=1" in your terminal to disable
+
+# The suffix of source filenames.
+source_suffix = '.rst'
+
+# The master toctree document.
+master_doc = 'index'
+
+# General information about the project.
+project = u'ansible-zuul-jobs'
+copyright = u'2018, Ansible contributors'
+
+# If true, '()' will be appended to :func: etc. cross-reference text.
+add_function_parentheses = True
+
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+add_module_names = True
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'sphinx'
+
+# -- Options for HTML output --------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  Major themes that come with
+# Sphinx are currently 'default' and 'sphinxdoc'.
+# html_theme_path = ["."]
+# html_theme = '_theme'
+# html_static_path = ['static']
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = '%sdoc' % project
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title, author, documentclass
+# [howto/manual]).
+latex_documents = [
+    ('index',
+     '%s.tex' % project,
+     u'%s Documentation' % project,
+     u'Ansible project', 'manual'),
+]
+
+# Example configuration for intersphinx: refer to the Python standard library.
+#intersphinx_mapping = {'http://docs.python.org/': None}

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,12 @@
+.. include:: ../../README.rst
+
+.. toctree::
+   :maxdepth: 2
+
+   jobs
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`

--- a/doc/source/jobs.rst
+++ b/doc/source/jobs.rst
@@ -1,0 +1,5 @@
+Jobs
+=====
+
+.. zuul:autojobs::
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = ansible-zuul-jobs
+summary = A set of Ansible playbooks used by Ansible projects CI system
+description-file =
+    README.rst
+author = Ansible contributors
+home-page = https://www.ansible.com
+classifier =
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python
+
+[build_sphinx]
+all-files = 1
+warning-is-error = 1
+source-dir = doc/source
+build-dir = doc/build

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2013 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import setuptools
+
+# In python < 2.7.4, a lazy loading of package `pbr` will break
+# setuptools if some other modules registered functions in `atexit`.
+# solution from: http://bugs.python.org/issue15881#msg170215
+try:
+    import multiprocessing  # noqa
+except ImportError:
+    pass
+
+setuptools.setup(
+    setup_requires=['pbr>=2.0'],
+    pbr=True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 flake8
+zuul-sphinx>=0.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,9 @@ basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 
+[testenv:docs]
+commands = python setup.py build_sphinx
+
 [testenv:linters]
 commands =
   flake8 {posargs}

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,7 +2,7 @@
     check:
       jobs:
         - tox-docs
-#        - tox-linters
+        - tox-linters
     gate:
       jobs:
         - tox-docs

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,8 +1,9 @@
 - project:
     check:
       jobs:
+        - tox-docs
 #        - tox-linters
-        - noop
     gate:
       jobs:
+        - tox-docs
         - tox-linters


### PR DESCRIPTION
This uses the zuul-sphinx plugin to start generating documentation
around our zuul jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>