### PR TITLE
Move base job into ansible-zuul-jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,3 +1,10 @@
+- job:
+    name: base
+    parent: base-minimal
+    abstract: true
+    description: |
+      The base job for the Ansible Network installation of Zuul.
+
 ##
 # `ansible-test sanity`
 # Single job tests multiple Python versions


### PR DESCRIPTION
This moves the base job in-tree making it untrusted. Making it easier
for users to make changes and get pre-merge testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>