### PR TITLE
Configure unbound for base jobs

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -1,5 +1,13 @@
 - hosts: all
   tasks:
+    # NOTE(pabelanger): We run this role in its own play to ensure unbound is
+    # restarted before proceeding with any other role. This is because we use
+    # notify / handler to restart the unbound service. With ansible notify
+    # actions are triggered at the end of each block of tasks in a play.
+    - name: Run configure-unbound role
+      include_role:
+        name: configure-unbound
+
     - name: Run validate-host role
       include_role:
         name: validate-host

--- a/roles/configure-unbound/README.rst
+++ b/roles/configure-unbound/README.rst
@@ -1,0 +1,48 @@
+An ansible role to dynamically configure DNS forwarders for the
+``unbound`` caching service.  IPv6 will be preferred when there is a
+usable IPv6 default route, otherwise IPv4.
+
+.. note:: This is not a standalone unbound configuration role.  Base
+          setup is done during image builds in
+          ``project-config:nodepool/elements/nodepool-base/finalise.d/89-unbound``;
+          here we just do dynamic configuration of forwarders based on
+          the interfaces available on the actual host.
+
+**Role Variables**
+
+.. zuul:rolevar:: unbound_primary_nameserver_v4
+   :default: 208.67.222.222 (OpenDNS)
+
+   The primary IPv4 nameserver for fowarding requests
+
+.. zuul:rolevar:: unbound_secondary_nameserver_v4
+   :default: 8.8.8.8 (Google)
+
+   The secondary IPv4 nameserver for fowarding requests
+
+.. zuul:rolevar:: unbound_primary_nameserver_v6
+   :default: 2620:0:ccc::2 (OpenDNS)
+
+   The primary IPv6 nameserver for fowarding requests
+
+.. zuul:rolevar:: unbound_secondary_nameserver_v6
+   :default: 2001:4860:4860::8888 (Google)
+
+   The seconary IPv6 nameserver for fowarding requests
+
+.. zuul:rolevar:: unbound_cache_max_ttl
+   :default: 86400
+
+   Maximum TTL in seconds to keep successful queries cached for.
+
+   This TTL will have precedence if the DNS record TTL is higher.
+   For example, a TTL of 90000 would be reduced to 86400.
+
+.. zuul:rolevar:: unbound_cache_min_ttl
+   :default: 0
+
+   Minimum TTL in seconds to keep queries cached for.
+   Note that this is effective for both successful and failed queries.
+
+   This TTL will have precedence if the DNS record TTL is lower.
+   For example, a TTL of 60 would be raised to 900.

--- a/roles/configure-unbound/defaults/main.yaml
+++ b/roles/configure-unbound/defaults/main.yaml
@@ -1,0 +1,24 @@
+# OpenDNS
+unbound_primary_nameserver_v6: "2620:0:ccc::2"
+unbound_primary_nameserver_v4: "208.67.222.222"
+
+# Google
+unbound_secondary_nameserver_v6: "2001:4860:4860::8888"
+unbound_secondary_nameserver_v4: "8.8.8.8"
+
+# Time to live maximum for  RRsets  and  messages  in  the  cache.
+# Default  is  86400  seconds  (1  day).  If the maximum kicks in,
+# responses to clients still get decrementing TTLs  based  on  the
+# original  (larger)  values.   When the internal TTL expires, the
+# cache item has expired.  Can be set lower to force the  resolver
+# to query for data often, and not trust (very large) TTL values.
+unbound_cache_max_ttl: 86400
+
+# Time  to  live  minimum  for  RRsets  and messages in the cache.
+# Default is 0.  If the minimum kicks in, the data is  cached  for
+# longer than the domain owner intended, and thus less queries are
+# made to look up the data.  Zero makes sure the data in the cache
+# is  as the domain owner intended, higher values, especially more
+# than an hour or so, can lead to trouble as the data in the cache
+# does not match up with the actual data any more.
+unbound_cache_min_ttl: 0

--- a/roles/configure-unbound/handlers/main.yaml
+++ b/roles/configure-unbound/handlers/main.yaml
@@ -1,0 +1,5 @@
+- name: Restart unbound
+  become: yes
+  service:
+    name: unbound
+    state: restarted

--- a/roles/configure-unbound/tasks/main.yaml
+++ b/roles/configure-unbound/tasks/main.yaml
@@ -1,0 +1,75 @@
+- name: Ensure that Unbound is installed
+  become: yes
+  package:
+    name: unbound
+
+# ansible_default_ipv6 can either be undefined (no ipv6) or blank (no
+# routable address).  We only want to use ipv6 if it's available &
+# routable; combine these checks into this fact.
+- name: Check for IPv6
+  when:
+    - hostvars[inventory_hostname]['ansible_default_ipv6'] is defined
+    - hostvars[inventory_hostname]['ansible_default_ipv6']['address'] is defined
+  set_fact:
+    unbound_use_ipv6: True
+
+# Use *only* ipv6 resolvers if ipv6 is present and routable.  This
+# avoids traversing potential NAT when using ipv4 which can be
+# unreliable.
+- name: Set IPv6 nameservers
+  when:
+    - unbound_use_ipv6 is defined
+  set_fact:
+    unbound_primary_nameserver: '{{ unbound_primary_nameserver_v6 }}'
+    unbound_secondary_nameserver: '{{ unbound_secondary_nameserver_v6 }}'
+
+# Fallback to default ipv4 if there is no ipv6 available as this
+# causes timeouts and failovers that are unnecesary.
+- name: Set IPv4 nameservers
+  when:
+    - unbound_use_ipv6 is not defined
+  set_fact:
+    unbound_primary_nameserver: '{{ unbound_primary_nameserver_v4 }}'
+    unbound_secondary_nameserver: '{{ unbound_secondary_nameserver_v4 }}'
+
+- name: Include OS-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}.yaml"
+    - "{{ ansible_os_family }}.yaml"
+    - "default.yaml"
+
+- name: Ensure Unbound conf.d directory exists
+  become: yes
+  file:
+    path: "{{ unbound_confd }}"
+    state: directory
+
+- name: Configure unbound forwarding
+  become: yes
+  template:
+    dest: "{{ unbound_confd }}/forwarding.conf"
+    owner: root
+    group: root
+    mode: 0644
+    src: forwarding.conf.j2
+  notify:
+    - Restart unbound
+
+- name: Configure unbound TTL
+  become: yes
+  template:
+    dest: "{{ unbound_confd }}/ttl.conf"
+    owner: root
+    group: root
+    mode: 0644
+    src: ttl.conf.j2
+  notify:
+    - Restart unbound
+
+- name: Start unbound
+  become: yes
+  service:
+    name: unbound
+    state: started
+    enabled: yes

--- a/roles/configure-unbound/templates/forwarding.conf.j2
+++ b/roles/configure-unbound/templates/forwarding.conf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+forward-zone:
+  name: "."
+  forward-addr: {{ unbound_primary_nameserver }}
+  forward-addr: {{ unbound_secondary_nameserver }}

--- a/roles/configure-unbound/templates/ttl.conf.j2
+++ b/roles/configure-unbound/templates/ttl.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+server:
+    cache-min-ttl: {{ unbound_cache_min_ttl }}
+    cache-max-ttl: {{ unbound_cache_max_ttl }}

--- a/roles/configure-unbound/vars/Debian.yaml
+++ b/roles/configure-unbound/vars/Debian.yaml
@@ -1,0 +1,1 @@
+unbound_confd: /etc/unbound/unbound.conf.d

--- a/roles/configure-unbound/vars/default.yaml
+++ b/roles/configure-unbound/vars/default.yaml
@@ -1,0 +1,1 @@
+unbound_confd: /etc/unbound/conf.d


### PR DESCRIPTION
We need to ensure we have working DNS for nodepool nodes. This uses the
configure-unbound role from zuul-jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>