### PR TITLE
Drop python3 support for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ skipsdist = True
 envlist = linters
 
 [testenv]
-basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 


### PR DESCRIPTION
We are looking to update the default nodeset to centos-7,
which doesn't have python3 :( If we do want to test python3, we can look
to using fedora-28 or even ubuntu-bionic.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>