### PR TITLE
Cap sphinx below 1.8.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 flake8
+sphinx<1.8.0
 zuul-sphinx>=0.2.0


### PR DESCRIPTION
See we might be having a python3 compat issue on centos-7, cap for now
until we can debug.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>