### PR TITLE
Set base job to use centos-7 nodeset

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -4,6 +4,8 @@
     abstract: true
     description: |
       The base job for the Ansible Network installation of Zuul.
+    # TODO(pabelanger): Move this to base-minimal for the long term.
+    nodeset: centos-7
 
 ##
 # `ansible-test sanity`


### PR DESCRIPTION
This starts to run jobs that parent to base in vexxhost. We do it here
first to confirm everything is working well, then we'll move into
base-minimal.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>