### PR TITLE
Remove nodeset from base job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -4,8 +4,6 @@
     abstract: true
     description: |
       The base job for the Ansible Network installation of Zuul.
-    # TODO(pabelanger): Move this to base-minimal for the long term.
-    nodeset: centos-7
 
 ##
 # `ansible-test sanity`


### PR DESCRIPTION
This is now the default for base-minimal, so no need to duplicate.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>