### PR TITLE
Move prepare-workspace to base playbook

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -1,0 +1,5 @@
+- hosts: all
+  tasks:
+    - name: Run prepare-workspace role
+      include_role:
+        name: prepare-workspace

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -4,6 +4,7 @@
     abstract: true
     description: |
       The base job for the Ansible Network installation of Zuul.
+    pre-run: playbooks/base/pre.yaml
 
 ##
 # `ansible-test sanity`


### PR DESCRIPTION
There is no reason this needs to be in base-minimal, by moving it to
base we can take advantage of pre merge testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>