### PR TITLE
Move validate-host role to base job

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -3,3 +3,7 @@
     - name: Run prepare-workspace role
       include_role:
         name: prepare-workspace
+
+    - name: Run validate-host role
+      include_role:
+        name: validate-host

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,6 +1,6 @@
 - job:
     name: base
-    parent: base-minimal
+    parent: base-minimal-test
     abstract: true
     description: |
       The base job for the Ansible Network installation of Zuul.


### PR DESCRIPTION
Again, this role can be untrusted as nothing about it requires a trusted
playbook. This makes it easy if we ever need to test changes to it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>