### PR TITLE
Parent base to base-minimal

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,6 +1,6 @@
 - job:
     name: base
-    parent: base-minimal-test
+    parent: base-minimal
     abstract: true
     description: |
       The base job for the Ansible Network installation of Zuul.


### PR DESCRIPTION
The previous commit changed the parent by mistake, roll back to
base-minimal as parent.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>