### PR TITLE
Remove perpare-workspace from base job

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -1,9 +1,5 @@
 - hosts: all
   tasks:
-    - name: Run prepare-workspace role
-      include_role:
-        name: prepare-workspace
-
     - name: Run validate-host role
       include_role:
         name: validate-host


### PR DESCRIPTION
Sadly, we need to move this back to base-minimal, as ansible/ansible
uses symlinks. This makes zuul unhappy.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>