### PR TITLE
Add fedora-latest nodeset

### DIFF
--- a/roles/ansible-role-tests/tasks/main.yaml
+++ b/roles/ansible-role-tests/tasks/main.yaml
@@ -24,6 +24,6 @@
 
 # FIXME May need to add a sanity check that ansible --version returns the correct version of Python
 - name: Run integration tests
-  command: "/home/zuul-worker/.local/bin/ansible-playbook --inventory ./inventory test.yml -vv"
+  command: ansible-playbook --inventory ./inventory test.yml -vv
   args:
     chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/tests/"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -18,11 +18,7 @@
       # Needed for access to ansible-test
       - name: ansible/ansible
         override-checkout: devel
-    nodeset:
-      nodes:
-        # We need a container with various Python versions available
-        name: container
-        label: f27-oci
+    nodeset: fedora-latest
 
 ##
 # ansible-role-tests
@@ -50,11 +46,7 @@
          Example ``ansible`` or ``"git+https://github.com/ansible/ansible.git@devel"``
 
     run: playbooks/ansible-role-tests/run.yaml
-    nodeset:
-      nodes:
-        # We need a container with various Python versions available
-        name: container
-        label: f27-oci
+    nodeset: fedora-latest
 
 # All Ansible Core versions that are supported since Ansible 2.5 need to be listed here
 # as the job definitions are used by all repos

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -3,3 +3,9 @@
     nodes:
       - name: centos-7
         label: ansible-centos-7
+
+- nodeset:
+    name: fedora-latest
+    nodes:
+      - name: fedora-28
+        label: ansible-fedora-28


### PR DESCRIPTION
This gives the ability for jobs to use fedora-28 if needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>