### PR TITLE
Fix rebase error with base pre-run playbook

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -8,6 +8,8 @@
       include_role:
         name: configure-unbound
 
+- hosts: all
+  tasks:
     - name: Run validate-host role
       include_role:
         name: validate-host


### PR DESCRIPTION
We need unbound to be in its own play, as to properly restart unbound.
This fixes a rebase error.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>