### PR TITLE
Add fedora-28 nodeset

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -3,3 +3,9 @@
     nodes:
       - name: centos-7
         label: ansible-centos-7
+
+- nodeset:
+    name: fedora-latest
+    nodes:
+      - name: fedora-28
+        label: ansible-fedora-28


### PR DESCRIPTION
This creates a fedora-28 nodeset which we'll start to use to migrate
away from fedora container images.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>