### PR TITLE
Switch yang to use fedora-latest

### DIFF
--- a/roles/ansible-role-tests/tasks/main.yaml
+++ b/roles/ansible-role-tests/tasks/main.yaml
@@ -24,6 +24,6 @@
 
 # FIXME May need to add a sanity check that ansible --version returns the correct version of Python
 - name: Run integration tests
-  command: "/home/zuul-worker/.local/bin/ansible-playbook --inventory ./inventory test.yml -vv"
+  command: "{{ ansible_user_dir }}/.local/bin/ansible-playbook --inventory ./inventory test.yml -vv"
   args:
     chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/tests/"

--- a/roles/ansible-test-sanity/tasks/main.yml
+++ b/roles/ansible-test-sanity/tasks/main.yml
@@ -84,13 +84,13 @@
 - name: Run ansible-test against Python 3.6
   command: "{{ ansible_path }}/test/runner/ansible-test sanity --python 3.6 {{ standard_options }} {{ skip_options }} {{ test_targets }}"
 
+# NOTE(pabelanger): Skip python2.6 here, since this is fedora-28.
 # Secondly, run each of the SanityMultipleVersion tests against the remaining available Python versions
 - name: Run ansible-test for SanityMultipleVersion
   command: "{{ ansible_path }}/test/runner/ansible-test sanity --python {{ item }} {{ standard_options }} --test ansible-doc --test compile --test import {{ test_targets }}"
   with_items:
-    - "2.6"
     - "2.7"
-    - "3.5"
+    - "3.6"
 
 ##
 # Check for failures

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -12,17 +12,14 @@
 #
 - job:
     name: ansible-test-sanity
+    parent: unittests
     description: ansible-test sanity
     run: playbooks/ansible-test-sanity/run.yaml
     required-projects:
       # Needed for access to ansible-test
       - name: ansible/ansible
         override-checkout: devel
-    nodeset:
-      nodes:
-        # We need a container with various Python versions available
-        name: container
-        label: f27-oci
+    nodeset: fedora-latest
 
 ##
 # ansible-role-tests
@@ -30,6 +27,7 @@
 
 - job:
     name: ansible-role-tests-base
+    parent: unittests
     description: |
       Parent job for ``ansible role`` tests for testing against different
       Ansible and Python versions
@@ -50,11 +48,7 @@
          Example ``ansible`` or ``"git+https://github.com/ansible/ansible.git@devel"``
 
     run: playbooks/ansible-role-tests/run.yaml
-    nodeset:
-      nodes:
-        # We need a container with various Python versions available
-        name: container
-        label: f27-oci
+    nodeset: fedora-latest
 
 # All Ansible Core versions that are supported since Ansible 2.5 need to be listed here
 # as the job definitions are used by all repos


### PR DESCRIPTION
This is another step to remove the dependency on rdocloud.  Currently
fedora-latest runs in vexxhost, but we can also add it back into
rdocloud.  Right now, we don't have containers in vexxhost.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>