### PR TITLE
Remove hardcoded zuul-worker reference

### DIFF
--- a/roles/ansible-role-tests/tasks/main.yaml
+++ b/roles/ansible-role-tests/tasks/main.yaml
@@ -24,6 +24,6 @@
 
 # FIXME May need to add a sanity check that ansible --version returns the correct version of Python
 - name: Run integration tests
-  command: "/home/zuul-worker/.local/bin/ansible-playbook --inventory ./inventory test.yml -vv"
+  command: "{{ ansible_user_dir }}/.local/bin/ansible-playbook --inventory ./inventory test.yml -vv"
   args:
     chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/tests/"


### PR DESCRIPTION
We can use the ansible_user_dir ansible variable to find out this
information, which is helpful is we end up switching nodes.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>