### PR TITLE
Revert "Drop python3 support for tox"

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 flake8
-sphinx<1.8.0
+sphinx
 zuul-sphinx>=0.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 envlist = linters
 
 [testenv]
+basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 


### PR DESCRIPTION
Now that we run fedora-latest (fedora-28) nodeset by default, we have
access to python3.

This reverts commit 243d1be4d4e197d23c0cd8abe7ba2975c6cb2756.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>