### PR TITLE
Add new nodesets for 1vcpu / 4vcpu

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -5,7 +5,31 @@
         label: ansible-centos-7
 
 - nodeset:
+    name: centos-7-1vcpu
+    nodes:
+      - name: centos-7
+        label: ansible-centos-7-1vcpu
+
+- nodeset:
+    name: centos-7-4vcpu
+    nodes:
+      - name: centos-7
+        label: ansible-centos-7-4vcpu
+
+- nodeset:
     name: fedora-latest
     nodes:
       - name: fedora-28
         label: ansible-fedora-28
+
+- nodeset:
+    name: fedora-latest-1vcpu
+    nodes:
+      - name: fedora-28
+        label: ansible-fedora-28-1vcpu
+
+- nodeset:
+    name: fedora-latest-4vcpu
+    nodes:
+      - name: fedora-28
+        label: ansible-fedora-28-4vcpu


### PR DESCRIPTION
Give jobs more control over which flavors they can test will. This
allows for smaller jobs like linters / docs to only use 1vcpu, saving
quota so we can run more of them.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>