### PR TITLE
Add release-notes-jobs project-template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -27,3 +27,14 @@
     gate:
       jobs:
         - noop
+
+- project-template:
+    name: release-notes-jobs
+    description: |
+      Runs the release notes test and publish jobs.
+    check:
+      jobs:
+        - build-releasenotes
+    gate:
+      jobs:
+        - build-releasenotes


### PR DESCRIPTION
All projects producing release notes will eventually run these jobs.
We'll also use this template when we start to publish them.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>