### PR TITLE
Create build-tox-docs project-template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -29,12 +29,14 @@
         - noop
 
 - project-template:
-    name: release-notes-jobs
+    name: build-tox-docs
     description: |
-      Runs the release notes test and publish jobs.
+      Runs tox docs jobs without publishing.
     check:
       jobs:
-        - build-reno-releasenotes
+        - tox-docs:
+            nodeset: fedora-latest-1vcpu
     gate:
       jobs:
-        - build-reno-releasenotes
+        - tox-docs:
+            nodeset: fedora-latest-1vcpu

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,9 +1,9 @@
 - project:
+    templates:
+      - build-tox-docs
     check:
       jobs:
-        - tox-docs
         - tox-linters
     gate:
       jobs:
         - tox-docs
-        - tox-linters


### PR DESCRIPTION
And use nodeset fedora-latest-1vcpu. We also remove the unsed
release-notes-jobs template.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>