### PR TITLE
Update system-required template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -9,7 +9,7 @@
     # and we can report invalid zuul.yaml files.
     check:
       jobs: []
-    merge-check:
+    unlabel-on-push:
       jobs:
         - noop
 


### PR DESCRIPTION
We are not ready to use merge pipeline right now, but we do want all
projects to use the unlabel-on-push pipeline.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>