### PR TITLE
Remove package install of unbound

### DIFF
--- a/roles/configure-unbound/tasks/main.yaml
+++ b/roles/configure-unbound/tasks/main.yaml
@@ -1,8 +1,3 @@
-- name: Ensure that Unbound is installed
-  become: yes
-  package:
-    name: unbound
-
 # ansible_default_ipv6 can either be undefined (no ipv6) or blank (no
 # routable address).  We only want to use ipv6 if it's available &
 # routable; combine these checks into this fact.


### PR DESCRIPTION
Until we fix /etc/resolv.conf for point to localhost, don't install the
package, because we hit DNS here.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>