### PR TITLE
Add ansible-network-release-jobs project-template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -40,3 +40,14 @@
       jobs:
         - tox-docs:
             nodeset: fedora-latest-1vcpu
+
+- project-template:
+    name: ansible-role-release-jobs
+    description: |
+      Runs release jobs for an Ansible role.
+    pre-release:
+      jobs:
+        - release-ansible-role
+    release:
+      jobs:
+        - release-ansible-role


### PR DESCRIPTION
Eventually all ansible-network roles will use this project-template for
tagging releases.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>