### PR TITLE
Create ansible-python-jobs project-template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -42,6 +42,19 @@
             nodeset: fedora-latest-1vcpu
 
 - project-template:
+    name: ansible-python-jobs
+    description: |
+      Runs Ansible PTI jobs for python.
+    check:
+      jobs:
+        - tox-linters:
+            nodeset: fedora-latest-1vcpu
+    gate:
+      jobs:
+        - tox-linters:
+            nodeset: fedora-latest-1vcpu
+
+- project-template:
     name: ansible-role-release-jobs
     description: |
       Runs release jobs for an Ansible role.

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,9 +1,4 @@
 - project:
     templates:
+      - ansible-python-jobs
       - build-tox-docs
-    check:
-      jobs:
-        - tox-linters
-    gate:
-      jobs:
-        - tox-linters


### PR DESCRIPTION
Projects can start to use this project-template to start linting jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>