### PR TITLE
Add ensure-output-dirs role to base job

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -1,5 +1,11 @@
 - hosts: all
   tasks:
+    - name: Run ensure-output-dirs role
+      include_role:
+        name: ensure-output-dirs
+
+- hosts: all
+  tasks:
     # NOTE(pabelanger): We run this role in its own play to ensure unbound is
     # restarted before proceeding with any other role. This is because we use
     # notify / handler to restart the unbound service. With ansible notify


### PR DESCRIPTION
Start work on our new logs collection process for zuul, this will
simplify how jobs collect / public things.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>