### PR TITLE
Remove centos-7 and fedora-latest nodesets

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -19,7 +19,7 @@
       # Needed for access to ansible-test
       - name: ansible/ansible
         override-checkout: devel
-    nodeset: fedora-latest
+    nodeset: fedora-latest-4vcpu
 
 ##
 # ansible-role-tests
@@ -45,7 +45,7 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: devel
-    nodeset: fedora-latest
+    nodeset: fedora-latest-4vcpu
 
 # All Ansible Core versions that are supported since Ansible 2.5 need to be listed here
 # as the job definitions are used by all repos

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -1,10 +1,4 @@
 - nodeset:
-    name: centos-7
-    nodes:
-      - name: centos-7
-        label: ansible-centos-7
-
-- nodeset:
     name: centos-7-1vcpu
     nodes:
       - name: centos-7
@@ -15,12 +9,6 @@
     nodes:
       - name: centos-7
         label: ansible-centos-7-4vcpu
-
-- nodeset:
-    name: fedora-latest
-    nodes:
-      - name: fedora-28
-        label: ansible-fedora-28
 
 - nodeset:
     name: fedora-latest-1vcpu


### PR DESCRIPTION
This will force jobs to pick how many vcpu they need, which hopefully is
better for the end user to fully understand the resources being used.

Depends-On: https://github.com/ansible-network/zuul-config/pull/125
Signed-off-by: Paul Belanger <pabelanger@redhat.com>