### PR TITLE
Add validate-dco-license role

### DIFF
--- a/roles/validate-dco-license/defaults/main.yaml
+++ b/roles/validate-dco-license/defaults/main.yaml
@@ -1,0 +1,8 @@
+---
+dco_license_failure: |
+  One or more commits have not been signed properly using --signoff.
+
+  The meaning of a signoff depends on the project, but it typically certifies
+  that committer has the rights to submit this work under the same license and
+  agrees to a Developer Certificate of Origin
+  (see http://developercertificate.org/ for more information).

--- a/roles/validate-dco-license/tasks/main.yaml
+++ b/roles/validate-dco-license/tasks/main.yaml
@@ -1,0 +1,25 @@
+- name: Developer Certificate of Origin (DCO) license check
+  shell:
+    cmd: |
+      set -e
+      result=0
+      for commit in $(git cherry -v origin/{{ zuul.branch }} HEAD | cut -d " " -f2)
+      do
+        if ! git show -s $commit | grep -q "Signed-off-by:"; then
+          echo "---"
+          git show -s $commit
+          echo "---"
+          echo "does not have a Signed-off-by header"
+          result=1
+        fi
+      done
+      exit $result
+    chdir: "{{ zuul.project.src_dir }}"
+    executable: /bin/bash
+  register: _dco
+  failed_when: _dco.rc > 1
+
+- name: License check failed
+  fail:
+    msg: "{{ dco_license_failure }}"
+  when: _dco.rc != 0


### PR DESCRIPTION
This is our first attempt at checking each commit has used the
--signoff flag.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>