### PR TITLE
Remove override-checkout setting for ansible-sanity jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -17,8 +17,7 @@
     run: playbooks/ansible-test-sanity/run.yaml
     required-projects:
       # Needed for access to ansible-test
-      - name: ansible/ansible
-        override-checkout: devel
+      - name: github.com/ansible/ansible
     nodeset: fedora-latest-4vcpu
 
 ##


### PR DESCRIPTION
This means we hardcode all branchces to used the devel version of
ansible, but we actually want to use same stable branch for both our
roles and ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>