### PR TITLE
Add tox-py27 to ansible-python-jobs template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -49,10 +49,14 @@
       jobs:
         - tox-linters:
             nodeset: fedora-latest-1vcpu
+        - tox-py27:
+            nodeset: centos-7-1vcpu
     gate:
       jobs:
         - tox-linters:
             nodeset: fedora-latest-1vcpu
+        - tox-py27:
+            nodeset: centos-7-1vcpu
 
 - project-template:
     name: ansible-role-release-jobs


### PR DESCRIPTION
As we continue our march to ensure all roles run tests the same way, we
plan on replacing the existing ansible-role-test jobs with tox entry
points.

This shouldn't be a breaking change for projects, and will start to
allow an easy way for jobs to run tests locally.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>