### PR TITLE
Add ansible-network-tox zuul-jobs

### DIFF
--- a/playbooks/ansible-network-tox-base/post.yaml
+++ b/playbooks/ansible-network-tox-base/post.yaml
@@ -1,0 +1,20 @@
+- hosts: all
+  tasks:
+    - name: Ensure ara-report directory exists
+      file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs/logs/ara-report"
+        state: directory
+
+    - name: Generate ARA HTML output
+      shell: "ara generate html {{ ansible_user_dir }}/zuul-output/logs/logs/ara-report"
+      args:
+        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/.tox/{{ tox_envlist }}/bin"
+
+    # TODO: Migrate to fetch-zuul-logs when
+    # https://review.openstack.org/#/c/583346/ is merged.
+    - name: Collect log output
+      synchronize:
+        dest: "{{ zuul.executor.log_root }}/"
+        mode: pull
+        src: "{{ ansible_user_dir }}/zuul-output/logs/"
+        verify_host: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -6,6 +6,18 @@
       The base job for the Ansible Network installation of Zuul.
     pre-run: playbooks/base/pre.yaml
 
+- job:
+    name: ansible-network-tox-base
+    parent: tox
+    abstract: true
+    post-run: playbooks/ansible-network-tox-base/post.yaml
+
+- job:
+    name: ansible-network-tox-py27
+    parent: ansible-network-tox-base
+    vars:
+      tox_envlist: py27
+
 ##
 # `ansible-test sanity`
 # Single job tests multiple Python versions


### PR DESCRIPTION
The default tox jobs we are using for testing are great, but we want to
wrap around some extra bits. Like, generating ARA reports for nested
ansible and setting up SSH keys for localhost.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>