### PR TITLE
Add ansible-role-tag-jobs project-template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -64,3 +64,11 @@
     release:
       jobs:
         - release-ansible-role
+
+- project-template:
+    name: ansible-role-tag-jobs
+    description: |
+      Runs tag jobs for an Ansible role.
+    tag:
+      jobs:
+        - release-ansible-role


### PR DESCRIPTION
We need this until we figure out semver for our ansible roles. This
provides a specific pipeline for tag jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>