### PR TITLE
Share gate queue with ansible-network/zuul-config

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,3 +2,5 @@
     templates:
       - ansible-python-jobs
       - build-tox-docs
+    gate:
+      queue: ansible-network/zuul-config


### PR DESCRIPTION
Since both of these repos tend to share a lot of common jobs, we can
place them into the same queue. This allows depends-on to work properly,
even when we don't share common jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>