### PR TITLE
Switch linters and docs to python3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,15 @@ skipsdist = True
 envlist = linters
 
 [testenv]
-basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:docs]
+basepython = python3
 commands = python setup.py build_sphinx
 
 [testenv:linters]
+basepython = python3
 commands =
   flake8 {posargs}
 


### PR DESCRIPTION
This is incase we every add centos-7 jobs, it doesn't support python3.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>