### PR TITLE
Add build-ansible-role-tarball job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -24,6 +24,15 @@
     vars:
       tox_envlist: py36
 
+- job:
+    name: build-ansible-role-tarball
+    parent: tox
+    description:
+      Build an ansible role tarball but do not upload it anywhere.
+    vars:
+      tox_envlist: venv
+      tox_extra_args: -vv -- mazer build .
+
 ##
 # `ansible-test sanity`
 # Single job tests multiple Python versions


### PR DESCRIPTION
This is an example job of how we can leverage tox and mazer to produce
tarballs of our ansible roles.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>