### PR TITLE
Add dco-license job to system-required template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -5,10 +5,12 @@
 
       This is automatically added to all projects in Ansible Network CI, no
       repository should use this directly.
-    # Include a check queue so that initially every repo has a check queue
-    # and we can report invalid zuul.yaml files.
     check:
-      jobs: []
+      jobs:
+        - dco-license
+    gate:
+      jobs:
+        - dco-license
     unlabel-on-push:
       jobs:
         - noop


### PR DESCRIPTION
All jobs need to check if the developer has signed a DCO. This means,
all PRs now much include 'Signed-off-by' headers.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>