### PR TITLE
Run configure-mirrors-fork role

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -23,3 +23,11 @@
     - name: Run configure-swap role
       include_role:
         name: configure-swap
+
+    - name: Run configure-mirrors-fork role
+      include_role:
+        name: configure-mirrors-fork
+      vars:
+        # NOTE(pabelanger): This assumes all our nodes are fedora, we should
+        # fix this.
+        package_mirror: http://download.fedoraproject.org/pub/fedora/linux

--- a/roles/configure-mirrors-fork/README.rst
+++ b/roles/configure-mirrors-fork/README.rst
@@ -1,0 +1,23 @@
+# NOTE(pabelanger): this is a fork of the configure-mirrors role in zuul-jobs
+# which removes the pip mirrors, we don't actually want to do that.
+
+An ansible role to configure services to use mirrors.
+
+**Role Variables**
+
+.. zuul:rolevar:: mirror_fqdn
+   :default: {{ zuul_site_mirror_fqdn }}
+
+   The base host for mirror servers.
+
+.. zuul:rolevar:: pypi_mirror
+
+   URL to override the generated pypi mirror url based on
+   :zuul:rolevar:`configure-mirrors.mirror_fqdn`.
+
+.. zuul:rolevar:: set_apt_mirrors_trusted
+   :default: False
+
+   Set to True in order to tag APT mirrors as trusted, needed
+   when accessing unsigned mirrors with newer releases like
+   Ubuntu Bionic.

--- a/roles/configure-mirrors-fork/defaults/main.yaml
+++ b/roles/configure-mirrors-fork/defaults/main.yaml
@@ -1,0 +1,4 @@
+mirror_fqdn: "{{ zuul_site_mirror_fqdn|default(omit) }}"
+pypi_mirror: "http://{{ mirror_fqdn }}/pypi/simple"
+set_apt_mirrors_trusted: False
+wheel_mirror: "http://{{ mirror_fqdn }}/wheel/{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}-{{ ansible_architecture | lower }}"

--- a/roles/configure-mirrors-fork/handlers/main.yaml
+++ b/roles/configure-mirrors-fork/handlers/main.yaml
@@ -1,0 +1,33 @@
+# The apt module can not be used for this since it installs python-apt
+# which can not work until this command fixes the cache.
+- name: Update apt cache
+  become: yes
+  command: apt-get update
+  # ANSIBLE0006: ignore, since we cannot use the apt module
+  tags:
+    - skip_ansible_lint
+
+- name: Update dnf cache
+  become: yes
+  command: "{{ item }}"
+  with_items:
+    - dnf clean all
+    - dnf makecache
+
+- name: Update yum cache
+  become: yes
+  command: "{{ item }}"
+  with_items:
+    - yum clean all
+    - yum makecache
+
+- name: Update zypper cache
+  become: yes
+  command: "{{ item }}"
+  with_items:
+    - zypper clean
+    - zypper refresh
+
+- name: Update Gentoo cache
+  become: yes
+  command: emerge-webrsync

--- a/roles/configure-mirrors-fork/tasks/main.yaml
+++ b/roles/configure-mirrors-fork/tasks/main.yaml
@@ -1,0 +1,4 @@
+- name: Set up infrastructure mirrors
+  include: mirror.yaml
+  when: mirror_fqdn is defined
+  static: no

--- a/roles/configure-mirrors-fork/tasks/mirror.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror.yaml
@@ -1,0 +1,15 @@
+- name: Include OS-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}.{{ ansible_architecture }}.yaml"
+    - "{{ ansible_distribution }}.yaml"
+    - "{{ ansible_os_family }}.yaml"
+    - "default.yaml"
+
+- name: Setup distribution specific packaging mirrors
+  include: "{{ item }}"
+  static: no
+  with_first_found:
+    - "mirror/{{ ansible_distribution }}.yaml"
+    - "mirror/{{ ansible_os_family }}.yaml"
+    - "mirror/default.yaml"

--- a/roles/configure-mirrors-fork/tasks/mirror/CentOS.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/CentOS.yaml
@@ -1,0 +1,25 @@
+- name: Install CentOS repository files
+  become: yes
+  template:
+    dest: "/{{ item }}"
+    group: root
+    mode: 0644
+    owner: root
+    src: "{{ item }}.j2"
+  with_items:
+    - etc/yum.repos.d/CentOS-Base.repo
+    - etc/yum.repos.d/epel.repo
+  notify:
+    - Update yum cache
+
+# http://dnf.readthedocs.io/en/latest/conf_ref.html#options-for-both-main-and-repo
+# deltarpm is useful when the bottleneck is the network throughput.
+# It also requires additional drpm packages to be hosted by the mirrors which
+# is not done by default.
+- name: Disable deltrarpm
+  become: yes
+  ini_file:
+    path: /etc/yum.conf
+    section: main
+    option: deltarpm
+    value: 0

--- a/roles/configure-mirrors-fork/tasks/mirror/Debian.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/Debian.yaml
@@ -1,0 +1,16 @@
+- name: Install Debian repository files
+  become: yes
+  template:
+    dest: "/{{ item }}"
+    group: root
+    mode: 0644
+    owner: root
+    src: "{{ item }}.j2"
+  with_items:
+    - etc/apt/sources.list.d/default.list
+    - etc/apt/sources.list.d/updates.list
+    - etc/apt/sources.list.d/backports.list
+    - etc/apt/sources.list.d/security.list
+    - etc/apt/apt.conf.d/99unauthenticated
+  notify:
+    - Update apt cache

--- a/roles/configure-mirrors-fork/tasks/mirror/Fedora.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/Fedora.yaml
@@ -1,0 +1,25 @@
+- name: Install Fedora repository files
+  become: yes
+  template:
+    dest: "/{{ item }}"
+    group: root
+    mode: 0644
+    owner: root
+    src: "{{ item }}.j2"
+  with_items:
+    - etc/yum.repos.d/fedora.repo
+    - etc/yum.repos.d/fedora-updates.repo
+  notify:
+    - Update dnf cache
+
+# http://dnf.readthedocs.io/en/latest/conf_ref.html#options-for-both-main-and-repo
+# deltarpm is useful when the bottleneck is the network throughput.
+# It also requires additional drpm packages to be hosted by the mirrors which
+# is not done by default.
+- name: Disable deltrarpm
+  become: yes
+  ini_file:
+    path: /etc/dnf/dnf.conf
+    section: main
+    option: deltarpm
+    value: "false"

--- a/roles/configure-mirrors-fork/tasks/mirror/Gentoo.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/Gentoo.yaml
@@ -1,0 +1,4 @@
+- name: Update Gentoo repository
+  command: echo "Syncs the Gentoo repository"
+  notify:
+    - Update Gentoo cache

--- a/roles/configure-mirrors-fork/tasks/mirror/Suse.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/Suse.yaml
@@ -1,0 +1,34 @@
+- name: set zypper base package repository (openSUSE Leap)
+  set_fact:
+      opensuse_repo_baseurl: "{{ package_mirror }}/distribution/leap/$releasever/repo/oss/"
+  when: not ansible_distribution | search("Tumbleweed")
+
+- name: set zypper base package repository (openSUSE Tumbleweed)
+  set_fact:
+      opensuse_repo_baseurl: "{{ package_mirror }}/tumbleweed/repo/oss/"
+  when: ansible_distribution | search("Tumbleweed")
+
+- name: Install Suse repository files
+  become: yes
+  template:
+    dest: "/{{ item }}"
+    group: root
+    mode: 0644
+    owner: root
+    src: "{{ item }}.j2"
+  with_items:
+    - etc/zypp/repos.d/repo-oss.repo
+  notify:
+    - Update zypper cache
+
+- name: Install openSUSE Leap Update repository
+  become: yes
+  template:
+    dest: /etc/zypp/repos.d/repo-update.repo
+    group: root
+    mode: 0644
+    owner: root
+    src: etc/zypp/repos.d/repo-update.repo.j2
+  notify:
+    - Update zypper cache
+  when: not ansible_distribution | search("Tumbleweed")

--- a/roles/configure-mirrors-fork/tasks/mirror/Ubuntu.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/Ubuntu.yaml
@@ -1,0 +1,13 @@
+- name: Install Ubuntu repository files
+  become: yes
+  template:
+    dest: "/{{ item }}"
+    group: root
+    mode: 0644
+    owner: root
+    src: "{{ item }}.j2"
+  with_items:
+    - etc/apt/sources.list
+    - etc/apt/apt.conf.d/99unauthenticated
+  notify:
+    - Update apt cache

--- a/roles/configure-mirrors-fork/tasks/mirror/default.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/default.yaml
@@ -1,0 +1,6 @@
+- name: Warn about unsupported distribution
+  debug:
+    msg: >
+      WARNING: {{ ansible_distribution }} mirrors are not supported either
+      by this role yet. The execution of the job will continue without setting
+      up cached mirrors.

--- a/roles/configure-mirrors-fork/templates/.pydistutils.cfg.j2
+++ b/roles/configure-mirrors-fork/templates/.pydistutils.cfg.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+[easy_install]
+index_url = {{ pypi_mirror }}
+allow_hosts = {{ mirror_fqdn }}

--- a/roles/configure-mirrors-fork/templates/etc/apt/apt.conf.d/99unauthenticated.j2
+++ b/roles/configure-mirrors-fork/templates/etc/apt/apt.conf.d/99unauthenticated.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+APT::Get::AllowUnauthenticated "true";

--- a/roles/configure-mirrors-fork/templates/etc/apt/sources.list.d/backports.list.j2
+++ b/roles/configure-mirrors-fork/templates/etc/apt/sources.list.d/backports.list.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+deb {{ package_mirror }} {{ ansible_distribution_release }}-backports main
+deb-src {{ package_mirror }} {{ ansible_distribution_release }}-backports main

--- a/roles/configure-mirrors-fork/templates/etc/apt/sources.list.d/default.list.j2
+++ b/roles/configure-mirrors-fork/templates/etc/apt/sources.list.d/default.list.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+deb {{ package_mirror }} {{ ansible_distribution_release }} main
+deb-src {{ package_mirror }} {{ ansible_distribution_release }} main

--- a/roles/configure-mirrors-fork/templates/etc/apt/sources.list.d/security.list.j2
+++ b/roles/configure-mirrors-fork/templates/etc/apt/sources.list.d/security.list.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+deb {{ security_mirror }} {{ ansible_distribution_release }} main
+deb-src {{ security_mirror }} {{ ansible_distribution_release }} main

--- a/roles/configure-mirrors-fork/templates/etc/apt/sources.list.d/updates.list.j2
+++ b/roles/configure-mirrors-fork/templates/etc/apt/sources.list.d/updates.list.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+deb {{ package_mirror }} {{ ansible_distribution_release }}-updates main
+deb-src {{ package_mirror }} {{ ansible_distribution_release }}-updates main

--- a/roles/configure-mirrors-fork/templates/etc/apt/sources.list.j2
+++ b/roles/configure-mirrors-fork/templates/etc/apt/sources.list.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+deb {% if set_apt_mirrors_trusted %}[ trusted=yes ] {% endif %}{{ package_mirror }} {{ ansible_distribution_release }} main universe
+deb {% if set_apt_mirrors_trusted %}[ trusted=yes ] {% endif %}{{ package_mirror }} {{ ansible_distribution_release }}-updates main universe
+deb {% if set_apt_mirrors_trusted %}[ trusted=yes ] {% endif %}{{ package_mirror }} {{ ansible_distribution_release }}-backports main universe
+deb {% if set_apt_mirrors_trusted %}[ trusted=yes ] {% endif %}{{ package_mirror }} {{ ansible_distribution_release }}-security main universe

--- a/roles/configure-mirrors-fork/templates/etc/pip.conf.j2
+++ b/roles/configure-mirrors-fork/templates/etc/pip.conf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+[global]
+timeout = 60
+index-url = {{ pypi_mirror }}
+trusted-host = {{ mirror_fqdn }}
+extra-index-url = {{ wheel_mirror }}

--- a/roles/configure-mirrors-fork/templates/etc/yum.repos.d/CentOS-Base.repo.j2
+++ b/roles/configure-mirrors-fork/templates/etc/yum.repos.d/CentOS-Base.repo.j2
@@ -1,0 +1,20 @@
+# {{ ansible_managed }}
+[base]
+name=CentOS-$releasever - Base
+baseurl={{ package_mirror }}/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+baseurl={{ package_mirror }}/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+baseurl={{ package_mirror }}/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/roles/configure-mirrors-fork/templates/etc/yum.repos.d/epel.repo.j2
+++ b/roles/configure-mirrors-fork/templates/etc/yum.repos.d/epel.repo.j2
@@ -1,0 +1,24 @@
+# {{ ansible_managed }}
+[epel]
+name=Extra Packages for Enterprise Linux 7 - $basearch
+baseurl={{ epel_mirror }}/7/$basearch
+failovermethod=priority
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+
+[epel-debuginfo]
+name=Extra Packages for Enterprise Linux 7 - $basearch - Debug
+baseurl={{ epel_mirror }}/7/$basearch/debug
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+gpgcheck=1
+
+[epel-source]
+name=Extra Packages for Enterprise Linux 7 - $basearch - Source
+baseurl={{ epel_mirror }}/7/SRPMS
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+gpgcheck=1

--- a/roles/configure-mirrors-fork/templates/etc/yum.repos.d/fedora-updates.repo.j2
+++ b/roles/configure-mirrors-fork/templates/etc/yum.repos.d/fedora-updates.repo.j2
@@ -1,0 +1,48 @@
+# {{ ansible_managed }}
+[updates]
+name=Fedora $releasever - $basearch - Updates
+failovermethod=priority
+{% if ansible_distribution_version | version_compare('28', '<') %}
+baseurl={{ package_mirror }}/updates/$releasever/$basearch/
+{% else %}
+baseurl={{ package_mirror }}/updates/$releasever/Everything/$basearch/
+{% endif %}
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[updates-debuginfo]
+name=Fedora $releasever - $basearch - Updates - Debug
+failovermethod=priority
+{% if ansible_distribution_version | version_compare('28', '<') %}
+baseurl={{ package_mirror }}/updates/$releasever/$basearch/debug/
+{% else %}
+baseurl={{ package_mirror }}/updates/$releasever/Everything/$basearch/debug/tree/
+{% endif %}
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[updates-source]
+name=Fedora $releasever - Updates Source
+failovermethod=priority
+{% if ansible_distribution_version | version_compare('28', '<') %}
+baseurl={{ package_mirror }}/updates/$releasever/SRPMS/
+{% else %}
+baseurl={{ package_mirror }}/updates/$releasever/Everything/source/tree/
+{% endif %}
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False

--- a/roles/configure-mirrors-fork/templates/etc/yum.repos.d/fedora.repo.j2
+++ b/roles/configure-mirrors-fork/templates/etc/yum.repos.d/fedora.repo.j2
@@ -1,0 +1,36 @@
+# {{ ansible_managed }}
+[fedora]
+name=Fedora $releasever - $basearch
+failovermethod=priority
+baseurl={{ package_mirror }}/releases/$releasever/Everything/$basearch/os/
+enabled=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-debuginfo]
+name=Fedora $releasever - $basearch - Debug
+failovermethod=priority
+baseurl={{ package_mirror }}/releases/$releasever/Everything/$basearch/debug/tree/
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-source]
+name=Fedora $releasever - Source
+failovermethod=priority
+baseurl={{ package_mirror }}/releases/$releasever/Everything/source/tree/
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False

--- a/roles/configure-mirrors-fork/templates/etc/zypp/repos.d/repo-oss.repo.j2
+++ b/roles/configure-mirrors-fork/templates/etc/zypp/repos.d/repo-oss.repo.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+[repo-oss]
+name=repo-oss
+enabled=1
+autorefresh=0
+baseurl={{ opensuse_repo_baseurl }}
+type=yast2
+keeppackages=0

--- a/roles/configure-mirrors-fork/templates/etc/zypp/repos.d/repo-update.repo.j2
+++ b/roles/configure-mirrors-fork/templates/etc/zypp/repos.d/repo-update.repo.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+[repo-update]
+name=repo-update
+enabled=1
+autorefresh=0
+baseurl={{ package_mirror }}/update/leap/$releasever/oss/
+type=rpm-md
+keeppackages=0

--- a/roles/configure-mirrors-fork/vars/CentOS.yaml
+++ b/roles/configure-mirrors-fork/vars/CentOS.yaml
@@ -1,0 +1,2 @@
+package_mirror: "http://{{ mirror_fqdn }}/{{ ansible_distribution | lower }}"
+epel_mirror: "http://{{ mirror_fqdn }}/epel"

--- a/roles/configure-mirrors-fork/vars/Debian.yaml
+++ b/roles/configure-mirrors-fork/vars/Debian.yaml
@@ -1,0 +1,2 @@
+package_mirror: "http://{{ mirror_fqdn }}/{{ ansible_distribution | lower }}"
+security_mirror: "http://{{ mirror_fqdn }}/{{ ansible_distribution | lower }}-security"

--- a/roles/configure-mirrors-fork/vars/Fedora.yaml
+++ b/roles/configure-mirrors-fork/vars/Fedora.yaml
@@ -1,0 +1,1 @@
+package_mirror: "http://{{ mirror_fqdn }}/{{ ansible_distribution | lower }}"

--- a/roles/configure-mirrors-fork/vars/Suse.yaml
+++ b/roles/configure-mirrors-fork/vars/Suse.yaml
@@ -1,0 +1,7 @@
+package_mirror: "http://{{ mirror_fqdn }}/opensuse"
+wheels_slug: "{%- if ansible_distribution == 'openSUSE Tumbleweed' -%}
+                 opensuse-tumbleweed-{{ ansible_architecture | lower }}
+              {%- else -%}
+                 {{ ansible_distribution | lower }}-{{ ansible_distribution_version }}-{{ ansible_architecture | lower }}
+              {%- endif -%}"
+wheel_mirror: "http://{{ mirror_fqdn }}/wheel/{{ wheels_slug }}"

--- a/roles/configure-mirrors-fork/vars/Ubuntu.aarch64.yaml
+++ b/roles/configure-mirrors-fork/vars/Ubuntu.aarch64.yaml
@@ -1,0 +1,1 @@
+package_mirror: "http://{{ mirror_fqdn }}/{{ ansible_distribution | lower }}-ports"

--- a/roles/configure-mirrors-fork/vars/Ubuntu.yaml
+++ b/roles/configure-mirrors-fork/vars/Ubuntu.yaml
@@ -1,0 +1,1 @@
+package_mirror: "http://{{ mirror_fqdn }}/{{ ansible_distribution | lower }}"

--- a/roles/configure-mirrors-fork/vars/default.yaml
+++ b/roles/configure-mirrors-fork/vars/default.yaml
@@ -1,0 +1,1 @@
+package_mirror:


### PR DESCRIPTION
This is the first step to creating regional mirrors, we actually want to
do this now, to disable deltarpms on fedora nodes.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>