### PR TITLE
Also update /etc/resolv.conf with configure-unbound

### DIFF
--- a/roles/configure-unbound/tasks/main.yaml
+++ b/roles/configure-unbound/tasks/main.yaml
@@ -62,6 +62,12 @@
   notify:
     - Restart unbound
 
+- name: Update resolv.conf to localhost
+  become: yes
+  copy:
+    content: nameserver 127.0.0.1
+    dest: /etc/resolv.conf
+
 - name: Start unbound
   become: yes
   service:


### PR DESCRIPTION
Make sure /etc/resolv.conf is properly setup to use local unbound
service.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>