### PR TITLE
Remove ansible-test-sanity jobs

### DIFF
--- a/playbooks/ansible-test-sanity/run.yaml
+++ b/playbooks/ansible-test-sanity/run.yaml
@@ -1,4 +1,0 @@
----
-- hosts: all
-  roles:
-      - ansible-test-sanity

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -31,20 +31,6 @@
       tox_envlist: py37
 
 ##
-# `ansible-test sanity`
-# Single job tests multiple Python versions
-#
-- job:
-    name: ansible-test-sanity
-    parent: unittests
-    description: ansible-test sanity
-    run: playbooks/ansible-test-sanity/run.yaml
-    required-projects:
-      # Needed for access to ansible-test
-      - name: github.com/ansible/ansible
-    nodeset: fedora-latest-4vcpu
-
-##
 # ansible-role-tests
 #
 


### PR DESCRIPTION
As we are moving more towards molecule for testing, we can drop the
ansible-test-sanity jobs.  Eventually ansible-test will be added into
molecule, and once that is done we can reconsider testing against it.

Today, this jobs in mostly non-voting as changes in devel could end up
breaking our roles.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>