### PR TITLE
Switch ansible-network-tox-py27 to centos-7 node

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -17,6 +17,7 @@
     parent: ansible-network-tox-base
     vars:
       tox_envlist: py27
+    nodeset: centos-7-1vcpu
 
 - job:
     name: ansible-network-tox-py36


### PR DESCRIPTION
Currently centos-7 has support for python2.7, and is a long term support
distro. It also gives us a 2nd distro to test against.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>