### PR TITLE
Update centos mirrors

### DIFF
--- a/roles/configure-mirrors-fork/vars/CentOS.yaml
+++ b/roles/configure-mirrors-fork/vars/CentOS.yaml
@@ -1,2 +1,2 @@
-package_mirror: http://mirror.centos.org/centos
-epel_mirror: http://download.fedoraproject.org/pub/epel
+epel_mirror: https://mirror.csclub.uwaterloo.ca/fedora/epel
+package_mirror: https://mirror.csclub.uwaterloo.ca/centos


### PR DESCRIPTION
This uses the same upstream mirror we have for Fedora nodes.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>